### PR TITLE
Include PHP 8 as supported version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         }
     ],
     "require": {
-        "php": "^7.1.3",
+        "php": "^7.1.3||^8.0",
         "illuminate/console": "^5.8|^6.0|^7.0|^8.0",
         "illuminate/support": "^5.8|^6.0|^7.0|^8.0"
     },


### PR DESCRIPTION
I installed the package using
```sh
composer require fschirinzi/translation-manager-for-laravel --dev --ignore-platform-reqs
```
and PHP 8.0, and it works fine. So I guess it’s safe to bump the PHP requirements.